### PR TITLE
Make xpack.infra configurable

### DIFF
--- a/jobs/kibana/spec
+++ b/jobs/kibana/spec
@@ -60,3 +60,21 @@ properties:
     default: 50
   kibana.config_options:
     description: "Additional options to append to kibana.yml (YAML format)."
+  xpack.infra.enabled:
+    description: "Set to `false` to disable the Logs and Infrastructure UI plugin Kibana. Defaults to `true`."
+  xpack.infra.sources.default.logAlias:
+    description: "Index pattern for matching indices that contain log data. Defaults to `filebeat-*`."
+  xpack.infra.sources.default.metricAlias:
+    description: "Index pattern for matching indices that contain Metricbeat data. Defaults to `metricbeat-*`."
+  xpack.infra.sources.default.fields.timestamp:
+    description: "Timestamp used to sort log entries. Defaults to `@timestamp`."
+  xpack.infra.sources.default.fields.message:
+    description: "Fields used to display messages in the Logs UI. Defaults to `['message', '@message']`."
+  xpack.infra.sources.default.fields.tiebreaker:
+    description: "Field used to break ties between two entries with the same timestamp. Defaults to `_doc`."
+  xpack.infra.sources.default.fields.host:
+    description: "Field used to identify hosts. Defaults to `beat.hostname`."
+  xpack.infra.sources.default.fields.container:
+    description: "Field used to identify Docker containers. Defaults to `docker.container.name`."
+  xpack.infra.sources.default.fields.pod:
+    description: "Field used to identify Kubernetes pods. Defaults to `kubernetes.pod.name`."

--- a/jobs/kibana/templates/config/kibana.yml
+++ b/jobs/kibana/templates/config/kibana.yml
@@ -128,3 +128,31 @@ elasticsearch.shardTimeout: <%= p('kibana.shard_timeout') %>
 <% if_p('kibana.config_options') do |config_options| %>
 <%= config_options.to_yaml.gsub(/---/, '') %>
 <% end %>
+
+<% if_p('xpack.infra.enabled') do |enabled| -%>
+xpack.infra.enabled: <%= enabled %>
+<% end -%>
+<% if_p('xpack.infra.sources.default.logAlias') do |logAlias| -%>
+xpack.infra.sources.default.logAlias: <%= logAlias %>
+<% end -%>
+<% if_p('xpack.infra.sources.default.metricAlias') do |metricAlias| -%>
+xpack.infra.sources.default.metricAlias: <%= metricAlias %>
+<% end -%>
+<% if_p('xpack.infra.sources.default.fields.timestamp') do |timestamp| -%>
+xpack.infra.sources.default.fields.timestamp: <%= timestamp %>
+<% end -%>
+<% if_p('xpack.infra.sources.default.fields.message') do |message| -%>
+xpack.infra.sources.default.fields.message: <%= message %>
+<% end -%>
+<% if_p('xpack.infra.sources.default.fields.tiebreaker') do |tiebreaker| -%>
+xpack.infra.sources.default.fields.tiebreaker: <%= tiebreaker %>
+<% end -%>
+<% if_p('xpack.infra.sources.default.fields.host') do |host| -%>
+xpack.infra.sources.default.fields.host: <%= host %>
+<% end -%>
+<% if_p('xpack.infra.sources.default.fields.container') do |container| -%>
+xpack.infra.sources.default.fields.container: <%= container %>
+<% end -%>
+<% if_p('xpack.infra.sources.default.fields.pod') do |pod| -%>
+xpack.infra.sources.default.fields.pod: <%= pod %>
+<% end -%>


### PR DESCRIPTION
X-Pack Infrastructure settings. One of the feature is Logs UI. `xpack.infra.sources.default.logAlias`'s default is `filebeat-*`, but this deployment does not use filebeat, it is useful for set it to `logstash-*`, `syslog-*`, `firehose-*`, etc for tailing logs.

Logs UI Settings in Kibana
https://www.elastic.co/guide/en/kibana/6.6/logs-ui-settings-kb.html

